### PR TITLE
Add profile module for shared multiplatform

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,0 +1,28 @@
+plugins {
+    kotlin("multiplatform") version "1.9.0"
+    id("com.android.library")
+    kotlin("plugin.serialization") version "1.9.0"
+}
+
+kotlin {
+    android()
+    ios()
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1")
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.0")
+                implementation("io.insert-koin:koin-core:3.4.0")
+            }
+        }
+        val androidMain by getting
+    }
+}
+
+android {
+    compileSdk = 33
+    defaultConfig {
+        minSdk = 24
+    }
+}

--- a/shared/src/androidMain/kotlin/com/pb/funora/profile/data/ProfileServiceImpl.kt
+++ b/shared/src/androidMain/kotlin/com/pb/funora/profile/data/ProfileServiceImpl.kt
@@ -1,0 +1,42 @@
+package com.pb.funora.profile.data
+
+import com.pb.funora.profile.model.AvatarSuggestion
+import com.pb.funora.profile.model.UserProfile
+import kotlinx.coroutines.delay
+
+class ProfileServiceImpl : ProfileService {
+    private var storedProfile = UserProfile(
+        id = "1",
+        name = "Guest",
+        avatarUrl = "https://example.com/avatar/default.png",
+        countryCode = "US",
+        badges = emptyList()
+    )
+
+    private val avatarsByCountry = mapOf(
+        "US" to listOf(
+            AvatarSuggestion("https://example.com/avatar/us1.png", "Star"),
+            AvatarSuggestion("https://example.com/avatar/us2.png", "Stripe")
+        ),
+        "TR" to listOf(
+            AvatarSuggestion("https://example.com/avatar/tr1.png", "Moon"),
+            AvatarSuggestion("https://example.com/avatar/tr2.png", "Sun")
+        )
+    )
+
+    override suspend fun fetchProfile(): UserProfile {
+        delay(300) // simulate network
+        return storedProfile
+    }
+
+    override suspend fun updateProfile(profile: UserProfile): UserProfile {
+        delay(300)
+        storedProfile = profile
+        return storedProfile
+    }
+
+    override suspend fun fetchAvatarSuggestions(countryCode: String): List<AvatarSuggestion> {
+        delay(300)
+        return avatarsByCountry[countryCode] ?: emptyList()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/profile/data/ProfileService.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/profile/data/ProfileService.kt
@@ -1,0 +1,10 @@
+package com.pb.funora.profile.data
+
+import com.pb.funora.profile.model.AvatarSuggestion
+import com.pb.funora.profile.model.UserProfile
+
+interface ProfileService {
+    suspend fun fetchProfile(): UserProfile
+    suspend fun updateProfile(profile: UserProfile): UserProfile
+    suspend fun fetchAvatarSuggestions(countryCode: String): List<AvatarSuggestion>
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/profile/model/AvatarSuggestion.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/profile/model/AvatarSuggestion.kt
@@ -1,0 +1,9 @@
+package com.pb.funora.profile.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AvatarSuggestion(
+    val url: String,
+    val description: String
+)

--- a/shared/src/commonMain/kotlin/com/pb/funora/profile/model/UserProfile.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/profile/model/UserProfile.kt
@@ -1,0 +1,12 @@
+package com.pb.funora.profile.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UserProfile(
+    val id: String,
+    val name: String,
+    val avatarUrl: String,
+    val countryCode: String,
+    val badges: List<String>
+)

--- a/shared/src/commonMain/kotlin/com/pb/funora/profile/repository/ProfileRepository.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/profile/repository/ProfileRepository.kt
@@ -1,0 +1,15 @@
+package com.pb.funora.profile.repository
+
+import com.pb.funora.profile.data.ProfileService
+import com.pb.funora.profile.model.AvatarSuggestion
+import com.pb.funora.profile.model.UserProfile
+
+class ProfileRepository(private val service: ProfileService) {
+    suspend fun getProfile(): UserProfile = service.fetchProfile()
+
+    suspend fun updateProfile(profile: UserProfile): UserProfile =
+        service.updateProfile(profile)
+
+    suspend fun getAvatarSuggestions(countryCode: String): List<AvatarSuggestion> =
+        service.fetchAvatarSuggestions(countryCode)
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/profile/ui/AvatarPicker.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/profile/ui/AvatarPicker.kt
@@ -1,0 +1,50 @@
+package com.pb.funora.profile.ui
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import com.pb.funora.profile.model.AvatarSuggestion
+
+@Composable
+fun AvatarPicker(
+    suggestions: List<AvatarSuggestion>,
+    onAvatarSelected: (String) -> Unit,
+    onGalleryPick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    LazyRow(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        contentPadding = PaddingValues(horizontal = 16.dp)
+    ) {
+        items(suggestions) { suggestion ->
+            Image(
+                painter = painterResource(""), // placeholder
+                contentDescription = suggestion.description,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .clickable { onAvatarSelected(suggestion.url) }
+            )
+        }
+        item {
+            IconButton(onClick = onGalleryPick) {
+                Icon(
+                    painterResource(""), // placeholder
+                    contentDescription = "Gallery",
+                    tint = Color.Gray
+                )
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/profile/ui/BadgeRow.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/profile/ui/BadgeRow.kt
@@ -1,0 +1,22 @@
+package com.pb.funora.profile.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun BadgeRow(badges: List<String>, modifier: Modifier = Modifier) {
+    LazyRow(modifier = modifier, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        items(badges) { badge ->
+            Row(modifier = Modifier.padding(4.dp)) {
+                Text(text = badge)
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/profile/ui/ProfileScreen.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/profile/ui/ProfileScreen.kt
@@ -1,0 +1,56 @@
+package com.pb.funora.profile.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.pb.funora.profile.model.UserProfile
+import com.pb.funora.profile.viewmodel.ProfileViewModel
+
+@Composable
+fun ProfileScreen(viewModel: ProfileViewModel, modifier: Modifier = Modifier) {
+    val state by viewModel.state.collectAsState()
+
+    Column(modifier = modifier.padding(16.dp)) {
+        if (state.isLoading) {
+            CircularProgressIndicator()
+        }
+        state.profile?.let { profile ->
+            ProfileContent(profile, onSave = viewModel::updateProfile)
+            Spacer(modifier = Modifier.padding(8.dp))
+            BadgeRow(profile.badges)
+            Spacer(modifier = Modifier.padding(8.dp))
+            AvatarPicker(state.suggestions, onAvatarSelected = { url ->
+                viewModel.updateProfile(profile.copy(avatarUrl = url))
+            }, onGalleryPick = { /*TODO*/ })
+        }
+        state.error?.let { Text(text = it) }
+        Button(onClick = viewModel::fetchProfile, modifier = Modifier.fillMaxWidth()) {
+            Text("Refresh")
+        }
+    }
+}
+
+@Composable
+private fun ProfileContent(profile: UserProfile, onSave: (UserProfile) -> Unit) {
+    var name by remember { mutableStateOf(profile.name) }
+    BasicTextField(
+        value = name,
+        onValueChange = { name = it },
+        modifier = Modifier.fillMaxWidth()
+    )
+    Button(onClick = { onSave(profile.copy(name = name)) }) {
+        Text("Save")
+    }
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/profile/usecase/GetAvatarSuggestionsUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/profile/usecase/GetAvatarSuggestionsUseCase.kt
@@ -1,0 +1,9 @@
+package com.pb.funora.profile.usecase
+
+import com.pb.funora.profile.model.AvatarSuggestion
+import com.pb.funora.profile.repository.ProfileRepository
+
+class GetAvatarSuggestionsUseCase(private val repository: ProfileRepository) {
+    suspend operator fun invoke(countryCode: String): List<AvatarSuggestion> =
+        repository.getAvatarSuggestions(countryCode)
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/profile/usecase/GetProfileUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/profile/usecase/GetProfileUseCase.kt
@@ -1,0 +1,8 @@
+package com.pb.funora.profile.usecase
+
+import com.pb.funora.profile.model.UserProfile
+import com.pb.funora.profile.repository.ProfileRepository
+
+class GetProfileUseCase(private val repository: ProfileRepository) {
+    suspend operator fun invoke(): UserProfile = repository.getProfile()
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/profile/usecase/UpdateProfileUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/profile/usecase/UpdateProfileUseCase.kt
@@ -1,0 +1,9 @@
+package com.pb.funora.profile.usecase
+
+import com.pb.funora.profile.model.UserProfile
+import com.pb.funora.profile.repository.ProfileRepository
+
+class UpdateProfileUseCase(private val repository: ProfileRepository) {
+    suspend operator fun invoke(profile: UserProfile): UserProfile =
+        repository.updateProfile(profile)
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/profile/viewmodel/ProfileState.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/profile/viewmodel/ProfileState.kt
@@ -1,0 +1,11 @@
+package com.pb.funora.profile.viewmodel
+
+import com.pb.funora.profile.model.AvatarSuggestion
+import com.pb.funora.profile.model.UserProfile
+
+data class ProfileState(
+    val profile: UserProfile? = null,
+    val suggestions: List<AvatarSuggestion> = emptyList(),
+    val isLoading: Boolean = false,
+    val error: String? = null
+)

--- a/shared/src/commonMain/kotlin/com/pb/funora/profile/viewmodel/ProfileViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/profile/viewmodel/ProfileViewModel.kt
@@ -1,0 +1,58 @@
+package com.pb.funora.profile.viewmodel
+
+import com.pb.funora.profile.model.UserProfile
+import com.pb.funora.profile.usecase.GetAvatarSuggestionsUseCase
+import com.pb.funora.profile.usecase.GetProfileUseCase
+import com.pb.funora.profile.usecase.UpdateProfileUseCase
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+class ProfileViewModel(
+    private val getProfile: GetProfileUseCase,
+    private val updateProfile: UpdateProfileUseCase,
+    private val getAvatarSuggestions: GetAvatarSuggestionsUseCase,
+    private val coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Main)
+) {
+    private val _state = MutableStateFlow(ProfileState())
+    val state: StateFlow<ProfileState> = _state
+
+    private var job: Job? = null
+
+    fun fetchProfile() {
+        job?.cancel()
+        job = coroutineScope.launch {
+            _state.value = _state.value.copy(isLoading = true, error = null)
+            runCatching {
+                val profile = getProfile()
+                val suggestions = getAvatarSuggestions(profile.countryCode)
+                _state.value.copy(
+                    profile = profile,
+                    suggestions = suggestions,
+                    isLoading = false
+                )
+            }.onSuccess { newState -> _state.value = newState }
+             .onFailure { _state.value = _state.value.copy(isLoading = false, error = it.message) }
+        }
+    }
+
+    fun updateProfile(profile: UserProfile) {
+        job?.cancel()
+        job = coroutineScope.launch {
+            _state.value = _state.value.copy(isLoading = true, error = null)
+            runCatching {
+                val updated = updateProfile(profile)
+                val suggestions = getAvatarSuggestions(updated.countryCode)
+                _state.value.copy(
+                    profile = updated,
+                    suggestions = suggestions,
+                    isLoading = false
+                )
+            }.onSuccess { newState -> _state.value = newState }
+             .onFailure { _state.value = _state.value.copy(isLoading = false, error = it.message) }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add shared profile module with model, data, repository, usecase, viewmodel, and Compose UI
- include mock ProfileService implementation
- configure shared module `build.gradle.kts`

## Testing
- `./gradlew build` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684c9e74e4488321b04bccafb4165274