### PR TITLE
Add Okey engine module

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    kotlin("multiplatform")
+}
+
+kotlin {
+    jvm()
+    ios()
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1")
+                implementation("io.insert-koin:koin-core:3.4.0")
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/games/okey/engine/OkeyEngine.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/games/okey/engine/OkeyEngine.kt
@@ -1,0 +1,63 @@
+package com.pb.funora.games.okey.engine
+
+import com.pb.funora.games.okey.model.GameState
+import com.pb.funora.games.okey.model.Tile
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlin.random.Random
+
+/**
+ * Simple in-memory game engine managing the deck and turns.
+ */
+class OkeyEngine {
+    private val mutex = Mutex()
+    private val deck = mutableListOf<Tile>()
+    private val players = mutableMapOf<Int, MutableList<Tile>>()
+    private val tilesOnTable = mutableListOf<Tile>()
+    private var currentPlayer: Int = 0
+
+    init {
+        initDeck()
+    }
+
+    private fun initDeck() {
+        deck.clear()
+        TileColor.values().forEach { color ->
+            for (i in 1..13) {
+                deck += Tile("${color.name}_$i", color, i)
+            }
+        }
+        deck.shuffle(Random(System.currentTimeMillis()))
+    }
+
+    suspend fun dealTiles(playerCount: Int = 4) = mutex.withLock {
+        players.clear()
+        repeat(playerCount) { player ->
+            players[player] = mutableListOf()
+            repeat(14) {
+                players[player]!!.add(deck.removeAt(0))
+            }
+        }
+        currentPlayer = 0
+    }
+
+    suspend fun playTile(tile: Tile) = mutex.withLock {
+        tilesOnTable.add(tile)
+        players[currentPlayer]?.remove(tile)
+        currentPlayer = (currentPlayer + 1) % players.size
+    }
+
+    suspend fun drawTile(): Tile = mutex.withLock {
+        val tile = deck.removeAt(0)
+        players[currentPlayer]?.add(tile)
+        tile
+    }
+
+    suspend fun getState(): GameState = mutex.withLock {
+        GameState(
+            tilesOnHand = players[currentPlayer]?.toList() ?: emptyList(),
+            tilesOnTable = tilesOnTable.toList(),
+            currentPlayer = currentPlayer
+        )
+    }
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/games/okey/engine/TileColor.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/games/okey/engine/TileColor.kt
@@ -1,0 +1,8 @@
+package com.pb.funora.games.okey.engine
+
+/**
+ * Possible tile colors in the game.
+ */
+enum class TileColor {
+    RED, BLUE, GREEN, BLACK
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/games/okey/model/GameState.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/games/okey/model/GameState.kt
@@ -1,0 +1,10 @@
+package com.pb.funora.games.okey.model
+
+/**
+ * Holds the current state of the game.
+ */
+data class GameState(
+    val tilesOnHand: List<Tile>,
+    val tilesOnTable: List<Tile>,
+    val currentPlayer: Int
+)

--- a/shared/src/commonMain/kotlin/com/pb/funora/games/okey/model/Tile.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/games/okey/model/Tile.kt
@@ -1,0 +1,9 @@
+package com.pb.funora.games.okey.model
+
+import com.pb.funora.games.okey.engine.TileColor
+
+data class Tile(
+    val id: String,
+    val color: TileColor,
+    val number: Int
+)

--- a/shared/src/commonMain/kotlin/com/pb/funora/games/okey/repository/GameRepository.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/games/okey/repository/GameRepository.kt
@@ -1,0 +1,14 @@
+package com.pb.funora.games.okey.repository
+
+import com.pb.funora.games.okey.model.GameState
+import com.pb.funora.games.okey.model.Tile
+
+/**
+ * Repository interface for game actions.
+ */
+interface GameRepository {
+    suspend fun startGame()
+    suspend fun play(tile: Tile)
+    suspend fun draw(): Tile
+    suspend fun getState(): GameState
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/games/okey/repository/GameRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/games/okey/repository/GameRepositoryImpl.kt
@@ -1,0 +1,29 @@
+package com.pb.funora.games.okey.repository
+
+import com.pb.funora.games.okey.engine.OkeyEngine
+import com.pb.funora.games.okey.model.GameState
+import com.pb.funora.games.okey.model.Tile
+
+/**
+ * In-memory implementation of [GameRepository] using [OkeyEngine].
+ */
+class GameRepositoryImpl(
+    private val engine: OkeyEngine = OkeyEngine()
+) : GameRepository {
+
+    override suspend fun startGame() {
+        engine.dealTiles()
+    }
+
+    override suspend fun play(tile: Tile) {
+        engine.playTile(tile)
+    }
+
+    override suspend fun draw(): Tile {
+        return engine.drawTile()
+    }
+
+    override suspend fun getState(): GameState {
+        return engine.getState()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/games/okey/ui/ControlPanel.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/games/okey/ui/ControlPanel.kt
@@ -1,0 +1,22 @@
+package com.pb.funora.games.okey.ui
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ControlPanel(onDraw: () -> Unit, onPlay: () -> Unit, currentPlayer: Int) {
+    Row(Modifier.padding(8.dp)) {
+        Button(onClick = onDraw, modifier = Modifier.padding(end = 8.dp)) {
+            Text("Draw")
+        }
+        Button(onClick = onPlay, modifier = Modifier.padding(end = 8.dp)) {
+            Text("Play")
+        }
+        Text("Player $currentPlayer turn")
+    }
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/games/okey/ui/OkeyTable.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/games/okey/ui/OkeyTable.kt
@@ -1,0 +1,33 @@
+package com.pb.funora.games.okey.ui
+
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.dp
+import com.pb.funora.games.okey.model.Tile
+
+@Composable
+fun OkeyTable(tiles: List<Tile>, onTilePlayed: (Tile) -> Unit) {
+    val tileState = remember { mutableStateListOf<Tile>().apply { addAll(tiles) } }
+
+    FlowRow(Modifier.padding(8.dp)) {
+        tileState.forEach { tile ->
+            TileView(
+                tile = tile,
+                modifier = Modifier
+                    .padding(4.dp)
+                    .pointerInput(tile) {
+                        detectDragGestures(onDragEnd = {
+                            onTilePlayed(tile)
+                            tileState.remove(tile)
+                        })
+                    }
+            )
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/games/okey/ui/TileView.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/games/okey/ui/TileView.kt
@@ -1,0 +1,30 @@
+package com.pb.funora.games.okey.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.pb.funora.games.okey.engine.TileColor
+import com.pb.funora.games.okey.model.Tile
+
+@Composable
+fun TileView(tile: Tile, modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .size(40.dp)
+            .background(colorForTile(tile.color))
+    ) {
+        Text(text = tile.number.toString(), color = Color.White)
+    }
+}
+
+private fun colorForTile(color: TileColor): Color = when (color) {
+    TileColor.RED -> Color.Red
+    TileColor.BLUE -> Color.Blue
+    TileColor.GREEN -> Color.Green
+    TileColor.BLACK -> Color.DarkGray
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/games/okey/usecase/DrawTileUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/games/okey/usecase/DrawTileUseCase.kt
@@ -1,0 +1,10 @@
+package com.pb.funora.games.okey.usecase
+
+import com.pb.funora.games.okey.model.Tile
+import com.pb.funora.games.okey.repository.GameRepository
+
+class DrawTileUseCase(private val repository: GameRepository) {
+    suspend operator fun invoke(): Tile {
+        return repository.draw()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/games/okey/usecase/GetGameStateUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/games/okey/usecase/GetGameStateUseCase.kt
@@ -1,0 +1,10 @@
+package com.pb.funora.games.okey.usecase
+
+import com.pb.funora.games.okey.model.GameState
+import com.pb.funora.games.okey.repository.GameRepository
+
+class GetGameStateUseCase(private val repository: GameRepository) {
+    suspend operator fun invoke(): GameState {
+        return repository.getState()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/games/okey/usecase/PlayTileUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/games/okey/usecase/PlayTileUseCase.kt
@@ -1,0 +1,10 @@
+package com.pb.funora.games.okey.usecase
+
+import com.pb.funora.games.okey.model.Tile
+import com.pb.funora.games.okey.repository.GameRepository
+
+class PlayTileUseCase(private val repository: GameRepository) {
+    suspend operator fun invoke(tile: Tile) {
+        repository.play(tile)
+    }
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/games/okey/usecase/StartGameUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/games/okey/usecase/StartGameUseCase.kt
@@ -1,0 +1,9 @@
+package com.pb.funora.games.okey.usecase
+
+import com.pb.funora.games.okey.repository.GameRepository
+
+class StartGameUseCase(private val repository: GameRepository) {
+    suspend operator fun invoke() {
+        repository.startGame()
+    }
+}


### PR DESCRIPTION
## Summary
- set up shared game module under `games/okey`
- implement model classes for game tiles and state
- add `OkeyEngine` with simple tile dealing, play and draw logic
- provide in-memory repository and use cases
- compose UI components for tiles, table and controls
- configure multiplatform build with coroutine and koin dependencies

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c9f34d70c8321adcf30f23d2c2b46