### PR TITLE
Add matchmaking module to shared

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+    kotlin("multiplatform")
+}
+
+kotlin {
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1")
+                implementation("io.insert-koin:koin-core:3.4.0")
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/matchmaking/model/MatchRequest.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/matchmaking/model/MatchRequest.kt
@@ -1,0 +1,7 @@
+package com.pb.funora.matchmaking.model
+
+data class MatchRequest(
+    val playerId: String,
+    val gameId: String,
+    val timestamp: Long
+)

--- a/shared/src/commonMain/kotlin/com/pb/funora/matchmaking/model/MatchResult.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/matchmaking/model/MatchResult.kt
@@ -1,0 +1,7 @@
+package com.pb.funora.matchmaking.model
+
+data class MatchResult(
+    val success: Boolean,
+    val opponent: PlayerInfo?,
+    val error: String?
+)

--- a/shared/src/commonMain/kotlin/com/pb/funora/matchmaking/model/PlayerInfo.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/matchmaking/model/PlayerInfo.kt
@@ -1,0 +1,8 @@
+package com.pb.funora.matchmaking.model
+
+data class PlayerInfo(
+    val id: String,
+    val name: String,
+    val rating: Int,
+    val isBot: Boolean
+)

--- a/shared/src/commonMain/kotlin/com/pb/funora/matchmaking/repository/MatchmakingRepository.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/matchmaking/repository/MatchmakingRepository.kt
@@ -1,0 +1,10 @@
+package com.pb.funora.matchmaking.repository
+
+import com.pb.funora.matchmaking.model.MatchRequest
+import com.pb.funora.matchmaking.model.MatchResult
+import com.pb.funora.matchmaking.service.MatchmakingService
+
+class MatchmakingRepository(private val service: MatchmakingService) {
+    suspend fun findMatch(request: MatchRequest): MatchResult = service.findMatch(request)
+    suspend fun cancelMatch(request: MatchRequest) = service.cancelMatch(request)
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/matchmaking/service/MatchmakingService.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/matchmaking/service/MatchmakingService.kt
@@ -1,0 +1,9 @@
+package com.pb.funora.matchmaking.service
+
+import com.pb.funora.matchmaking.model.MatchRequest
+import com.pb.funora.matchmaking.model.MatchResult
+
+interface MatchmakingService {
+    suspend fun findMatch(request: MatchRequest): MatchResult
+    suspend fun cancelMatch(request: MatchRequest)
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/matchmaking/service/MatchmakingServiceImpl.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/matchmaking/service/MatchmakingServiceImpl.kt
@@ -1,0 +1,50 @@
+package com.pb.funora.matchmaking.service
+
+import com.pb.funora.matchmaking.model.MatchRequest
+import com.pb.funora.matchmaking.model.MatchResult
+import com.pb.funora.matchmaking.model.PlayerInfo
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlin.random.Random
+
+class MatchmakingServiceImpl : MatchmakingService {
+    private val queue = mutableListOf<MatchRequest>()
+    private val mutex = Mutex()
+
+    override suspend fun findMatch(request: MatchRequest): MatchResult {
+        mutex.withLock {
+            val opponentIndex = queue.indexOfFirst { it.gameId == request.gameId && it.playerId != request.playerId }
+            if (opponentIndex != -1) {
+                val opponentReq = queue.removeAt(opponentIndex)
+                val opponentInfo = PlayerInfo(opponentReq.playerId, "Player ${'$'}{opponentReq.playerId}", 1000, false)
+                return MatchResult(true, opponentInfo, null)
+            }
+            queue.add(request)
+        }
+
+        val deadline = request.timestamp + 5000
+        while (System.currentTimeMillis() < deadline) {
+            mutex.withLock {
+                val opponentIndex = queue.indexOfFirst { it.gameId == request.gameId && it.playerId != request.playerId }
+                if (opponentIndex != -1) {
+                    queue.remove(request)
+                    val opponentReq = queue.removeAt(opponentIndex)
+                    val opponentInfo = PlayerInfo(opponentReq.playerId, "Player ${'$'}{opponentReq.playerId}", 1000, false)
+                    return MatchResult(true, opponentInfo, null)
+                }
+            }
+            delay(500)
+        }
+
+        mutex.withLock { queue.remove(request) }
+        val botInfo = PlayerInfo("bot_${'$'}{Random.nextInt(1000, 9999)}", "Bot", 1000, true)
+        return MatchResult(true, botInfo, null)
+    }
+
+    override suspend fun cancelMatch(request: MatchRequest) {
+        mutex.withLock {
+            queue.removeIf { it.playerId == request.playerId && it.gameId == request.gameId }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/matchmaking/ui/MatchmakingScreen.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/matchmaking/ui/MatchmakingScreen.kt
@@ -1,0 +1,55 @@
+package com.pb.funora.matchmaking.ui
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.Button
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.pb.funora.matchmaking.model.MatchRequest
+import com.pb.funora.matchmaking.viewmodel.MatchmakingViewModel
+
+@Composable
+fun MatchmakingScreen(viewModel: MatchmakingViewModel, playerId: String, gameId: String) {
+    val state by viewModel.state.collectAsState()
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        when {
+            state.opponent != null -> {
+                val opponent = state.opponent
+                Text(text = "Rakip: ${'$'}{opponent.name} (${opponent.rating})" + if (opponent.isBot) " [Bot]" else "")
+            }
+            state.isSearching -> {
+                CircularProgressIndicator()
+            }
+            state.errorMessage != null -> {
+                Text(text = state.errorMessage ?: "")
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        if (!state.isSearching && state.opponent == null) {
+            Button(onClick = {
+                val request = MatchRequest(playerId, gameId, System.currentTimeMillis())
+                viewModel.startSearch(request)
+            }) {
+                Text("Ara")
+            }
+        } else if (state.isSearching) {
+            Button(onClick = {
+                val request = MatchRequest(playerId, gameId, System.currentTimeMillis())
+                viewModel.cancelSearch(request)
+            }) {
+                Text("Vazgeç")
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/matchmaking/usecase/CancelMatchUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/matchmaking/usecase/CancelMatchUseCase.kt
@@ -1,0 +1,10 @@
+package com.pb.funora.matchmaking.usecase
+
+import com.pb.funora.matchmaking.model.MatchRequest
+import com.pb.funora.matchmaking.repository.MatchmakingRepository
+
+class CancelMatchUseCase(private val repository: MatchmakingRepository) {
+    suspend operator fun invoke(request: MatchRequest) {
+        repository.cancelMatch(request)
+    }
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/matchmaking/usecase/FindMatchUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/matchmaking/usecase/FindMatchUseCase.kt
@@ -1,0 +1,11 @@
+package com.pb.funora.matchmaking.usecase
+
+import com.pb.funora.matchmaking.model.MatchRequest
+import com.pb.funora.matchmaking.model.MatchResult
+import com.pb.funora.matchmaking.repository.MatchmakingRepository
+
+class FindMatchUseCase(private val repository: MatchmakingRepository) {
+    suspend operator fun invoke(request: MatchRequest): MatchResult {
+        return repository.findMatch(request)
+    }
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/matchmaking/viewmodel/MatchmakingState.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/matchmaking/viewmodel/MatchmakingState.kt
@@ -1,0 +1,9 @@
+package com.pb.funora.matchmaking.viewmodel
+
+import com.pb.funora.matchmaking.model.PlayerInfo
+
+data class MatchmakingState(
+    val isSearching: Boolean = false,
+    val opponent: PlayerInfo? = null,
+    val errorMessage: String? = null
+)

--- a/shared/src/commonMain/kotlin/com/pb/funora/matchmaking/viewmodel/MatchmakingViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/matchmaking/viewmodel/MatchmakingViewModel.kt
@@ -1,0 +1,46 @@
+package com.pb.funora.matchmaking.viewmodel
+
+import com.pb.funora.matchmaking.model.MatchRequest
+import com.pb.funora.matchmaking.usecase.FindMatchUseCase
+import com.pb.funora.matchmaking.usecase.CancelMatchUseCase
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlin.coroutines.CoroutineContext
+
+class MatchmakingViewModel(
+    private val findMatchUseCase: FindMatchUseCase,
+    private val cancelMatchUseCase: CancelMatchUseCase,
+    private val coroutineContext: CoroutineContext = Dispatchers.Default
+) {
+    private val _state = MutableStateFlow(MatchmakingState())
+    val state: StateFlow<MatchmakingState> = _state
+
+    private var searchJob: Job? = null
+
+    fun startSearch(request: MatchRequest) {
+        if (searchJob != null) return
+        _state.value = MatchmakingState(isSearching = true)
+        searchJob = CoroutineScope(coroutineContext).launch {
+            val result = findMatchUseCase(request)
+            if (result.success) {
+                _state.value = MatchmakingState(isSearching = false, opponent = result.opponent)
+            } else {
+                _state.value = MatchmakingState(isSearching = false, errorMessage = result.error)
+            }
+            searchJob = null
+        }
+    }
+
+    fun cancelSearch(request: MatchRequest) {
+        searchJob?.cancel()
+        CoroutineScope(coroutineContext).launch {
+            cancelMatchUseCase(request)
+        }
+        _state.value = MatchmakingState(isSearching = false)
+        searchJob = null
+    }
+}


### PR DESCRIPTION
## Summary
- add matchmaking data model, service, repository, use cases and viewmodel
- add compose UI for matchmaking screen
- include coroutines and koin dependencies in shared build script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c9f556c4c8321a985e78311a972b8