### PR TITLE
Add basic currency module

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    kotlin("multiplatform")
+    kotlin("plugin.serialization")
+}
+
+kotlin {
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1")
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.0")
+                implementation("io.insert-koin:koin-core:3.4.0")
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/currency/data/CurrencyService.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/currency/data/CurrencyService.kt
@@ -1,0 +1,10 @@
+package com.pb.funora.currency.data
+
+import com.pb.funora.currency.model.CoinTransaction
+
+interface CurrencyService {
+    suspend fun fetchBalance(): Long
+    suspend fun fetchTransactions(): List<CoinTransaction>
+    suspend fun stake(amount: Long)
+    suspend fun unstake(amount: Long)
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/currency/data/CurrencyServiceImpl.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/currency/data/CurrencyServiceImpl.kt
@@ -1,0 +1,65 @@
+package com.pb.funora.currency.data
+
+import com.pb.funora.currency.model.CoinTransaction
+import com.pb.funora.currency.model.TransactionType
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlin.random.Random
+import kotlin.system.getTimeMillis
+
+class CurrencyServiceImpl : CurrencyService {
+    private val mutex = Mutex()
+    private var balance = 1000L
+    private val transactions = mutableListOf<CoinTransaction>()
+    private var stakedAmount = 0L
+
+    override suspend fun fetchBalance(): Long = mutex.withLock { balance }
+
+    override suspend fun fetchTransactions(): List<CoinTransaction> =
+        mutex.withLock { transactions.toList() }
+
+    override suspend fun stake(amount: Long) {
+        mutex.withLock {
+            if (amount <= balance && amount > 0) {
+                balance -= amount
+                stakedAmount += amount
+                transactions += CoinTransaction(
+                    id = Random.nextInt().toString(),
+                    amount = amount,
+                    type = TransactionType.STAKE,
+                    timestamp = getTimeMillis()
+                )
+            }
+        }
+    }
+
+    override suspend fun unstake(amount: Long) {
+        mutex.withLock {
+            if (amount <= stakedAmount && amount > 0) {
+                stakedAmount -= amount
+                balance += amount
+                transactions += CoinTransaction(
+                    id = Random.nextInt().toString(),
+                    amount = amount,
+                    type = TransactionType.UNSTAKE,
+                    timestamp = getTimeMillis()
+                )
+            }
+        }
+    }
+
+    internal suspend fun marketPurchase(amount: Long): Boolean = mutex.withLock {
+        if (amount <= balance) {
+            balance -= amount
+            transactions += CoinTransaction(
+                id = Random.nextInt().toString(),
+                amount = amount,
+                type = TransactionType.MARKET_PURCHASE,
+                timestamp = getTimeMillis()
+            )
+            true
+        } else {
+            false
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/currency/data/MarketplaceService.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/currency/data/MarketplaceService.kt
@@ -1,0 +1,8 @@
+package com.pb.funora.currency.data
+
+import com.pb.funora.currency.model.MarketItem
+
+interface MarketplaceService {
+    suspend fun fetchItems(): List<MarketItem>
+    suspend fun purchaseItem(itemId: String): Boolean
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/currency/data/MarketplaceServiceImpl.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/currency/data/MarketplaceServiceImpl.kt
@@ -1,0 +1,22 @@
+package com.pb.funora.currency.data
+
+import com.pb.funora.currency.model.MarketItem
+import kotlin.random.Random
+
+class MarketplaceServiceImpl(
+    private val currencyService: CurrencyServiceImpl
+) : MarketplaceService {
+
+    private val items = listOf(
+        MarketItem("1", "Sword", 100, "A sharp blade"),
+        MarketItem("2", "Shield", 150, "Protect yourself"),
+        MarketItem("3", "Potion", 50, "Heals you")
+    )
+
+    override suspend fun fetchItems(): List<MarketItem> = items
+
+    override suspend fun purchaseItem(itemId: String): Boolean {
+        val item = items.find { it.itemId == itemId } ?: return false
+        return currencyService.marketPurchase(item.price)
+    }
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/currency/model/CoinTransaction.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/currency/model/CoinTransaction.kt
@@ -1,0 +1,11 @@
+package com.pb.funora.currency.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CoinTransaction(
+    val id: String,
+    val amount: Long,
+    val type: TransactionType,
+    val timestamp: Long
+)

--- a/shared/src/commonMain/kotlin/com/pb/funora/currency/model/MarketItem.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/currency/model/MarketItem.kt
@@ -1,0 +1,11 @@
+package com.pb.funora.currency.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MarketItem(
+    val itemId: String,
+    val name: String,
+    val price: Long,
+    val description: String
+)

--- a/shared/src/commonMain/kotlin/com/pb/funora/currency/model/StakeInfo.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/currency/model/StakeInfo.kt
@@ -1,0 +1,10 @@
+package com.pb.funora.currency.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class StakeInfo(
+    val stakedAmount: Long,
+    val earnedRewards: Long,
+    val since: Long
+)

--- a/shared/src/commonMain/kotlin/com/pb/funora/currency/model/TransactionType.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/currency/model/TransactionType.kt
@@ -1,0 +1,12 @@
+package com.pb.funora.currency.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class TransactionType {
+    EARN,
+    SPEND,
+    STAKE,
+    UNSTAKE,
+    MARKET_PURCHASE
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/currency/repository/CurrencyRepository.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/currency/repository/CurrencyRepository.kt
@@ -1,0 +1,11 @@
+package com.pb.funora.currency.repository
+
+import com.pb.funora.currency.data.CurrencyService
+import com.pb.funora.currency.model.CoinTransaction
+
+class CurrencyRepository(private val service: CurrencyService) {
+    suspend fun getBalance(): Long = service.fetchBalance()
+    suspend fun getTransactions(): List<CoinTransaction> = service.fetchTransactions()
+    suspend fun stake(amount: Long) = service.stake(amount)
+    suspend fun unstake(amount: Long) = service.unstake(amount)
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/currency/repository/MarketplaceRepository.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/currency/repository/MarketplaceRepository.kt
@@ -1,0 +1,9 @@
+package com.pb.funora.currency.repository
+
+import com.pb.funora.currency.data.MarketplaceService
+import com.pb.funora.currency.model.MarketItem
+
+class MarketplaceRepository(private val service: MarketplaceService) {
+    suspend fun getItems(): List<MarketItem> = service.fetchItems()
+    suspend fun purchase(itemId: String): Boolean = service.purchaseItem(itemId)
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/currency/ui/CurrencyScreen.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/currency/ui/CurrencyScreen.kt
@@ -1,0 +1,34 @@
+package com.pb.funora.currency.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import com.pb.funora.currency.viewmodel.CurrencyViewModel
+
+@Composable
+fun CurrencyScreen(viewModel: CurrencyViewModel) {
+    val state = viewModel.state.collectAsState().value
+
+    Column {
+        Text(text = "Balance: ${'$'}{state.balance}")
+        Row {
+            Button(onClick = { /* open stake dialog externally */ }) {
+                Text("Stake")
+            }
+            Button(onClick = { /* open unstake dialog externally */ }) {
+                Text("Unstake")
+            }
+        }
+        LazyColumn {
+            items(state.transactions) { tx ->
+                Text("${'$'}{tx.type}: ${'$'}{tx.amount}")
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/currency/ui/MarketplaceScreen.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/currency/ui/MarketplaceScreen.kt
@@ -1,0 +1,28 @@
+package com.pb.funora.currency.ui
+
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import com.pb.funora.currency.viewmodel.MarketplaceViewModel
+
+@Composable
+fun MarketplaceScreen(viewModel: MarketplaceViewModel) {
+    val state = viewModel.state.collectAsState().value
+
+    LazyVerticalGrid(columns = GridCells.Fixed(2)) {
+        items(state.items) { item ->
+            Card {
+                Text(item.name)
+                Text("${'$'}{item.price}")
+                Button(onClick = { viewModel.purchase(item.itemId) }) {
+                    Text("Satın Al")
+                }
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/currency/ui/StakeDialog.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/currency/ui/StakeDialog.kt
@@ -1,0 +1,27 @@
+package com.pb.funora.currency.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+
+@Composable
+fun StakeDialog(onConfirm: (Long) -> Unit, onCancel: () -> Unit) {
+    val amount = remember { mutableStateOf("") }
+
+    Column {
+        OutlinedTextField(value = amount.value, onValueChange = { amount.value = it }, label = { Text("Amount") })
+        Row {
+            Button(onClick = { amount.value.toLongOrNull()?.let(onConfirm) }) {
+                Text("Confirm")
+            }
+            Button(onClick = onCancel) {
+                Text("Cancel")
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/currency/usecase/GetBalanceUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/currency/usecase/GetBalanceUseCase.kt
@@ -1,0 +1,7 @@
+package com.pb.funora.currency.usecase
+
+import com.pb.funora.currency.repository.CurrencyRepository
+
+class GetBalanceUseCase(private val repository: CurrencyRepository) {
+    suspend operator fun invoke(): Long = repository.getBalance()
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/currency/usecase/GetMarketItemsUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/currency/usecase/GetMarketItemsUseCase.kt
@@ -1,0 +1,8 @@
+package com.pb.funora.currency.usecase
+
+import com.pb.funora.currency.model.MarketItem
+import com.pb.funora.currency.repository.MarketplaceRepository
+
+class GetMarketItemsUseCase(private val repository: MarketplaceRepository) {
+    suspend operator fun invoke(): List<MarketItem> = repository.getItems()
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/currency/usecase/GetTransactionsUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/currency/usecase/GetTransactionsUseCase.kt
@@ -1,0 +1,8 @@
+package com.pb.funora.currency.usecase
+
+import com.pb.funora.currency.model.CoinTransaction
+import com.pb.funora.currency.repository.CurrencyRepository
+
+class GetTransactionsUseCase(private val repository: CurrencyRepository) {
+    suspend operator fun invoke(): List<CoinTransaction> = repository.getTransactions()
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/currency/usecase/PurchaseItemUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/currency/usecase/PurchaseItemUseCase.kt
@@ -1,0 +1,7 @@
+package com.pb.funora.currency.usecase
+
+import com.pb.funora.currency.repository.MarketplaceRepository
+
+class PurchaseItemUseCase(private val repository: MarketplaceRepository) {
+    suspend operator fun invoke(itemId: String): Boolean = repository.purchase(itemId)
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/currency/usecase/StakeUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/currency/usecase/StakeUseCase.kt
@@ -1,0 +1,7 @@
+package com.pb.funora.currency.usecase
+
+import com.pb.funora.currency.repository.CurrencyRepository
+
+class StakeUseCase(private val repository: CurrencyRepository) {
+    suspend operator fun invoke(amount: Long) = repository.stake(amount)
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/currency/usecase/UnstakeUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/currency/usecase/UnstakeUseCase.kt
@@ -1,0 +1,7 @@
+package com.pb.funora.currency.usecase
+
+import com.pb.funora.currency.repository.CurrencyRepository
+
+class UnstakeUseCase(private val repository: CurrencyRepository) {
+    suspend operator fun invoke(amount: Long) = repository.unstake(amount)
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/currency/viewmodel/CurrencyState.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/currency/viewmodel/CurrencyState.kt
@@ -1,0 +1,11 @@
+package com.pb.funora.currency.viewmodel
+
+import com.pb.funora.currency.model.CoinTransaction
+import com.pb.funora.currency.model.StakeInfo
+
+data class CurrencyState(
+    val balance: Long = 0L,
+    val transactions: List<CoinTransaction> = emptyList(),
+    val stakeInfo: StakeInfo? = null,
+    val error: String? = null
+)

--- a/shared/src/commonMain/kotlin/com/pb/funora/currency/viewmodel/CurrencyViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/currency/viewmodel/CurrencyViewModel.kt
@@ -1,0 +1,58 @@
+package com.pb.funora.currency.viewmodel
+
+import com.pb.funora.currency.usecase.GetBalanceUseCase
+import com.pb.funora.currency.usecase.GetTransactionsUseCase
+import com.pb.funora.currency.usecase.StakeUseCase
+import com.pb.funora.currency.usecase.UnstakeUseCase
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class CurrencyViewModel(
+    private val getBalance: GetBalanceUseCase,
+    private val getTransactions: GetTransactionsUseCase,
+    private val stakeUseCase: StakeUseCase,
+    private val unstakeUseCase: UnstakeUseCase,
+    scope: CoroutineScope? = null
+) {
+    private val viewModelScope = scope ?: CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    private val _state = MutableStateFlow(CurrencyState())
+    val state: StateFlow<CurrencyState> = _state
+
+    fun loadBalance() {
+        viewModelScope.launch {
+            runCatching { getBalance() }
+                .onSuccess { balance -> _state.update { it.copy(balance = balance, error = null) } }
+                .onFailure { e -> _state.update { it.copy(error = e.message) } }
+        }
+    }
+
+    fun loadTransactions() {
+        viewModelScope.launch {
+            runCatching { getTransactions() }
+                .onSuccess { list -> _state.update { it.copy(transactions = list, error = null) } }
+                .onFailure { e -> _state.update { it.copy(error = e.message) } }
+        }
+    }
+
+    fun stake(amount: Long) {
+        viewModelScope.launch {
+            runCatching { stakeUseCase(amount) }
+                .onSuccess { loadBalance(); loadTransactions() }
+                .onFailure { e -> _state.update { it.copy(error = e.message) } }
+        }
+    }
+
+    fun unstake(amount: Long) {
+        viewModelScope.launch {
+            runCatching { unstakeUseCase(amount) }
+                .onSuccess { loadBalance(); loadTransactions() }
+                .onFailure { e -> _state.update { it.copy(error = e.message) } }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/pb/funora/currency/viewmodel/MarketplaceState.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/currency/viewmodel/MarketplaceState.kt
@@ -1,0 +1,9 @@
+package com.pb.funora.currency.viewmodel
+
+import com.pb.funora.currency.model.MarketItem
+
+data class MarketplaceState(
+    val items: List<MarketItem> = emptyList(),
+    val purchaseResult: Boolean? = null,
+    val error: String? = null
+)

--- a/shared/src/commonMain/kotlin/com/pb/funora/currency/viewmodel/MarketplaceViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/pb/funora/currency/viewmodel/MarketplaceViewModel.kt
@@ -1,0 +1,38 @@
+package com.pb.funora.currency.viewmodel
+
+import com.pb.funora.currency.usecase.GetMarketItemsUseCase
+import com.pb.funora.currency.usecase.PurchaseItemUseCase
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class MarketplaceViewModel(
+    private val getItems: GetMarketItemsUseCase,
+    private val purchaseUseCase: PurchaseItemUseCase,
+    scope: CoroutineScope? = null
+) {
+    private val viewModelScope = scope ?: CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    private val _state = MutableStateFlow(MarketplaceState())
+    val state: StateFlow<MarketplaceState> = _state
+
+    fun loadItems() {
+        viewModelScope.launch {
+            runCatching { getItems() }
+                .onSuccess { list -> _state.update { it.copy(items = list, error = null) } }
+                .onFailure { e -> _state.update { it.copy(error = e.message) } }
+        }
+    }
+
+    fun purchase(itemId: String) {
+        viewModelScope.launch {
+            runCatching { purchaseUseCase(itemId) }
+                .onSuccess { result -> _state.update { it.copy(purchaseResult = result, error = null) } }
+                .onFailure { e -> _state.update { it.copy(error = e.message) } }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create `currency` module under `shared`
- implement models, data services, repositories, use cases and viewmodels
- provide simple Compose UI components
- add dependencies for coroutines, serialization, koin in `build.gradle.kts`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c9f83259083219c5103aa5a3f982f